### PR TITLE
fix: parse remote entry from build plugin

### DIFF
--- a/packages/module-federation-metro/src/plugin.ts
+++ b/packages/module-federation-metro/src/plugin.ts
@@ -125,14 +125,19 @@ function generateRuntimePlugins(runtimePlugins: string[]) {
 
 function generateRemotes(remotes: Record<string, string> = {}) {
   const remotesEntries: string[] = [];
-  Object.entries(remotes).forEach(([remoteName, remoteEntry]) => {
+  Object.entries(remotes).forEach(([remoteAlias, remoteEntry]) => {
+    const remoteEntryParts = remoteEntry.split("@");
+    const remoteName = remoteEntryParts[0];
+    const remoteEntryUrl = remoteEntryParts.slice(1).join("@");
+
     remotesEntries.push(
       `{ 
-          alias: "${remoteName}", 
+          alias: "${remoteAlias}", 
           name: "${remoteName}", 
-          entry: "${remoteEntry}", 
+          entry: "${remoteEntryUrl}", 
           entryGlobalName: "${remoteName}", 
-          type: "var" }`
+          type: "var" 
+       }`
     );
   });
 

--- a/packages/module-federation-metro/src/runtime-plugin.ts
+++ b/packages/module-federation-metro/src/runtime-plugin.ts
@@ -30,8 +30,7 @@ const MetroCorePlugin: () => FederationRuntimePlugin = () => ({
     }
 
     try {
-      // this should be already split, and should contain only URL
-      await loadBundleAsync(entry.split("@")[1]);
+      await loadBundleAsync(entry);
 
       if (!globalThis.__METRO_FEDERATION__[entryGlobalName]) {
         throw new Error();


### PR DESCRIPTION
split remote entry into remote name & remote url

reference: https://module-federation.io/configure/remotes.html#remotes