### PR TITLE
fix: fetch on android

### DIFF
--- a/packages/module-federation-metro/async-require-host.js
+++ b/packages/module-federation-metro/async-require-host.js
@@ -1,1 +1,5 @@
+// fetchAsync.native.ts requires process.env.EXPO_OS to be set
+// since expo is optional, we set it to an empty string as a fallback
+process.env.EXPO_OS = process.env.EXPO_OS ?? "";
+
 require("./vendor/expo/async-require");

--- a/packages/module-federation-metro/src/runtime-plugin.ts
+++ b/packages/module-federation-metro/src/runtime-plugin.ts
@@ -18,7 +18,9 @@ const getPublicPath = (url: string) => {
 
 const buildUrlForEntryBundle = (entry: string) => {
   if (__DEV__) {
-    return `${entry}?lazy=true`;
+    // inlined by metro
+    const platform = require("react-native").Platform.OS;
+    return `${entry}?platform=${platform}&dev=${true}&lazy=${true}`;
   } else {
     return entry;
   }

--- a/packages/module-federation-metro/vendor/expo/async-require/fetchAsync.native.ts
+++ b/packages/module-federation-metro/vendor/expo/async-require/fetchAsync.native.ts
@@ -55,7 +55,7 @@ export function fetchAsync(
         'asyncRequest',
         url,
         {
-          'expo-platform': process.env.EXPO_OS ?? '',
+          'expo-platform': process.env.EXPO_OS,
         },
         '',
         'text',

--- a/packages/module-federation-metro/vendor/expo/async-require/fetchAsync.native.ts
+++ b/packages/module-federation-metro/vendor/expo/async-require/fetchAsync.native.ts
@@ -55,7 +55,7 @@ export function fetchAsync(
         'asyncRequest',
         url,
         {
-          'expo-platform': process.env.EXPO_OS,
+          'expo-platform': process.env.EXPO_OS ?? '',
         },
         '',
         'text',


### PR DESCRIPTION
- [x] - fixes the issue where `EXPO_OS` was undefined
- [x] - adds `platform` and `dev` query params to `loadBundleAsync` calls 

note: `adb reverse tcp:8082 tcp:8082` is still required