### PR TITLE
fix: patch bundle command for development in monorepo

### DIFF
--- a/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch
+++ b/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch
@@ -20,3 +20,15 @@ index 0f9977969bd44f9f418dd1ad7d054250097c547e..9ef78a997bfef177a623102531959d5a
    let sourceMapUrl = args.sourcemapOutput;
    if (sourceMapUrl != null && !args.sourcemapUseAbsolutePath) {
      sourceMapUrl = _path.default.basename(sourceMapUrl);
+diff --git a/dist/utils/loadMetroConfig.js b/dist/utils/loadMetroConfig.js
+index c0749e111d342611631c3eedc9c757936e8ff225..1405ad2b05d99120225563827aaddf07cdc35018 100644
+--- a/dist/utils/loadMetroConfig.js
++++ b/dist/utils/loadMetroConfig.js
+@@ -33,6 +33,7 @@ function getOverrideConfig(ctx, config) {
+     resolver,
+     serializer: {
+       getModulesRunBeforeMainModule: () => [
++        ...(config.serializer?.getModulesRunBeforeMainModule?.() || []),
+         require.resolve(
+           _path.default.join(
+             ctx.reactNativePath,

--- a/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch
+++ b/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch
@@ -1,12 +1,22 @@
-diff --git a/dist/utils/loadMetroConfig.js b/dist/utils/loadMetroConfig.js
-index c0749e111d342611631c3eedc9c757936e8ff225..1405ad2b05d99120225563827aaddf07cdc35018 100644
---- a/dist/utils/loadMetroConfig.js
-+++ b/dist/utils/loadMetroConfig.js
-@@ -33,6 +33,7 @@ function getOverrideConfig(ctx, config) {
-     resolver,
-     serializer: {
-       getModulesRunBeforeMainModule: () => [
-+        ...(config.serializer?.getModulesRunBeforeMainModule?.() || []),
-         require.resolve(
-           _path.default.join(
-             ctx.reactNativePath,
+diff --git a/dist/commands/bundle/buildBundle.js b/dist/commands/bundle/buildBundle.js
+index 0f9977969bd44f9f418dd1ad7d054250097c547e..9ef78a997bfef177a623102531959d5a2d210e74 100644
+--- a/dist/commands/bundle/buildBundle.js
++++ b/dist/commands/bundle/buildBundle.js
+@@ -53,7 +53,16 @@ async function buildBundleWithConfig(
+     );
+     throw new Error("Bundling failed");
+   }
+-  process.env.NODE_ENV = args.dev ? "development" : "production";
++  if (process.env.METRO_FEDERATION_DEV) {
++    // Don't set global NODE_ENV to production inside the monorepo
++    // because it breaks Metro's babel-register ad hoc transforms
++    // when building with args.dev === false
++    process.env.NODE_ENV = "development";
++  } else {
++    // This is used by a bazillion of npm modules we don't control so we don't
++    // have other choice than defining it as an env variable here.
++    process.env.NODE_ENV = args.dev ? "development" : "production";
++  }
+   let sourceMapUrl = args.sourcemapOutput;
+   if (sourceMapUrl != null && !args.sourcemapUseAbsolutePath) {
+     sourceMapUrl = _path.default.basename(sourceMapUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,7 +2286,7 @@ __metadata:
 
 "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch":
   version: 0.79.0
-  resolution: "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch::version=0.79.0&hash=9857f0"
+  resolution: "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch::version=0.79.0&hash=4b5b48"
   dependencies:
     "@react-native/dev-middleware": "npm:0.79.0"
     chalk: "npm:^4.0.0"
@@ -2301,7 +2301,7 @@ __metadata:
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true
-  checksum: 10c0/18df746d89f747cf1b7de7982c5ceb8ae2da901b06de57b86c211ddcec28f268a02b21ef4c775b8cf7c3e9722127c9af40f12cbeb532c5d0507ad1e8d9c5bf0d
+  checksum: 10c0/8f3ea6681477b7f7680b11296cac1f5363495fd88d8cca810fcf8651e91658306dabe6b89a2c92e0122d8efc1ec5001029e4fe7c3674ec1034a609a0af4aa779
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,7 +2286,7 @@ __metadata:
 
 "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch":
   version: 0.79.0
-  resolution: "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch::version=0.79.0&hash=6d9b53"
+  resolution: "@react-native/community-cli-plugin@patch:@react-native/community-cli-plugin@npm%3A0.79.0#~/.yarn/patches/@react-native-community-cli-plugin-npm-0.79.0-d467a2c1a8.patch::version=0.79.0&hash=9857f0"
   dependencies:
     "@react-native/dev-middleware": "npm:0.79.0"
     chalk: "npm:^4.0.0"
@@ -2301,7 +2301,7 @@ __metadata:
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true
-  checksum: 10c0/04b8c9eb5d6a88414c3ed414ba9234378dbed9c3ac0a4b32723f9b5716802303dc9da7bd607bb91c0678bb0154f68f5a609468b009d0c5de0846d72e74467d8a
+  checksum: 10c0/18df746d89f747cf1b7de7982c5ceb8ae2da901b06de57b86c211ddcec28f268a02b21ef4c775b8cf7c3e9722127c9af40f12cbeb532c5d0507ad1e8d9c5bf0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
similar fix to the one we do in our custom command to allow ad-hoc transpilation of metro and our package when running bundle command