### PR TITLE
fix: include deep import for version-first strategy

### DIFF
--- a/packages/module-federation-metro/src/plugin.ts
+++ b/packages/module-federation-metro/src/plugin.ts
@@ -8,6 +8,7 @@ import {
   SharedConfig,
   ModuleFederationConfig,
   ModuleFederationConfigNormalized,
+  Shared,
 } from "./types";
 
 declare global {
@@ -40,6 +41,15 @@ function getSharedString(options: ModuleFederationConfigNormalized) {
   return sharedString;
 }
 
+function getEarlySharedDeps(shared: Shared) {
+  return Object.keys(shared).filter((name) => {
+    if (name === "react") return true;
+    if (name === "react-native") return true;
+    if (name.startsWith("react-native/")) return true;
+    return false;
+  });
+}
+
 function getInitHostModule(options: ModuleFederationConfigNormalized) {
   const initHostPath = require.resolve("./runtime/init-host.js");
   let initHostModule = fs.readFileSync(initHostPath, "utf-8");
@@ -47,11 +57,7 @@ function getInitHostModule(options: ModuleFederationConfigNormalized) {
   const sharedString = getSharedString(options);
 
   // must be loaded synchronously at all times
-  const earlySharedDeps = [
-    "react",
-    "react-native",
-    "react-native/Libraries/Network/RCTNetworking",
-  ];
+  const earlySharedDeps = getEarlySharedDeps(options.shared);
 
   // Replace placeholders with actual values
   initHostModule = initHostModule
@@ -159,7 +165,7 @@ function getRemoteEntryModule(options: ModuleFederationConfigNormalized) {
   let remoteEntryModule = fs.readFileSync(remoteEntryTemplatePath, "utf-8");
 
   const sharedString = getSharedString(options);
-  const earlySharedDeps = ["react", "react-native"];
+  const earlySharedDeps = getEarlySharedDeps(options.shared);
 
   const exposes = options.exposes || {};
 

--- a/packages/module-federation-metro/src/plugin.ts
+++ b/packages/module-federation-metro/src/plugin.ts
@@ -47,7 +47,11 @@ function getInitHostModule(options: ModuleFederationConfigNormalized) {
   const sharedString = getSharedString(options);
 
   // must be loaded synchronously at all times
-  const earlySharedDeps = ["react", "react-native"];
+  const earlySharedDeps = [
+    "react",
+    "react-native",
+    "react-native/Libraries/Network/RCTNetworking",
+  ];
 
   // Replace placeholders with actual values
   initHostModule = initHostModule

--- a/packages/module-federation-metro/src/types.ts
+++ b/packages/module-federation-metro/src/types.ts
@@ -6,12 +6,14 @@ export interface SharedConfig {
   import?: false;
 }
 
+export type Shared = Record<string, SharedConfig>;
+
 export interface ModuleFederationConfig {
   name: string;
   filename?: string;
   remotes?: Record<string, string>;
   exposes?: Record<string, string>;
-  shared?: Record<string, SharedConfig>;
+  shared?: Shared;
   shareStrategy?: "loaded-first" | "version-first";
   plugins?: string[];
 }


### PR DESCRIPTION
### Summary

`version-first` approach broke because of not loading deep import from RN to the registry, this PR fixes this by adding that deep import to the explict early shared dependencies.

