### PR TITLE
Revert "fix: remove virtual modules creation for remotes"

### DIFF
--- a/packages/module-federation-metro/babel/shared-babel-plugin.js
+++ b/packages/module-federation-metro/babel/shared-babel-plugin.js
@@ -21,13 +21,23 @@ function getWrappedSharedImport(importName) {
     t.stringLiteral("mf:remote-module-registry"),
   ]);
 
-  // .loadAndGetShared(importName)
-  const loadAndGetSharedCall = t.callExpression(
-    t.memberExpression(requireCall, t.identifier("loadAndGetShared")),
+  // .loadSharedToRegistry('mini/button')
+  const loadCall = t.callExpression(
+    t.memberExpression(requireCall, t.identifier("loadSharedToRegistry")),
     [importArg]
   );
 
-  return loadAndGetSharedCall;
+  // import('mini/button')
+  const importCall = t.callExpression(t.import(), [importArg]);
+  importCall.__wasTransformed = true;
+
+  // .then(() => import('mini/button'))
+  const thenCall = t.callExpression(
+    t.memberExpression(loadCall, t.identifier("then")),
+    [t.arrowFunctionExpression([], importCall)]
+  );
+
+  return thenCall;
 }
 
 function moduleFederationSharedBabelPlugin() {

--- a/packages/module-federation-metro/src/runtime/remote-module-registry.js
+++ b/packages/module-federation-metro/src/runtime/remote-module-registry.js
@@ -16,16 +16,6 @@ function cloneModule(module, target) {
   });
 }
 
-export async function loadAndGetShared(id) {
-  await loadSharedToRegistry(id);
-  return getModuleFromRegistry(id);
-}
-
-export async function loadAndGetRemote(id) {
-  await loadRemoteToRegistry(id);
-  return getModuleFromRegistry(id);
-}
-
 export async function loadRemoteToRegistry(id) {
   const promise = loading[id];
   if (promise) {


### PR DESCRIPTION
### Summary

Reverts module-federation/metro-mf#34 since we still need virtual modules for remotes for sync imports