### PR TITLE
fix: babel transforms

### DIFF
--- a/packages/module-federation-metro/babel/remotes-babel-plugin.js
+++ b/packages/module-federation-metro/babel/remotes-babel-plugin.js
@@ -35,6 +35,10 @@ function moduleFederationRemotesBabelPlugin() {
     name: "module-federation-remotes-babel-plugin",
     visitor: {
       CallExpression(path, state) {
+        if (state.opts.blacklistedPaths.includes(state.filename)) {
+          return;
+        }
+
         if (isRemoteImport(path, state.opts)) {
           const wrappedImport = getWrappedRemoteImport(
             path.node.arguments[0].value

--- a/packages/module-federation-metro/babel/shared-babel-plugin.js
+++ b/packages/module-federation-metro/babel/shared-babel-plugin.js
@@ -35,6 +35,10 @@ function moduleFederationSharedBabelPlugin() {
     name: "module-federation-shared-babel-plugin",
     visitor: {
       CallExpression(path, state) {
+        if (state.opts.blacklistedPaths.includes(state.filename)) {
+          return;
+        }
+
         if (isSharedImport(path, state.opts)) {
           const wrappedImport = getWrappedSharedImport(
             path.node.arguments[0].value

--- a/packages/module-federation-metro/babel/shared-babel-plugin.js
+++ b/packages/module-federation-metro/babel/shared-babel-plugin.js
@@ -1,7 +1,7 @@
 const t = require("@babel/types");
 
 function getSharedRegExp(shared) {
-  return new RegExp(`^(${Object.keys(shared).join("|")})\/`);
+  return new RegExp(`^(${Object.keys(shared).join("|")})$`);
 }
 
 function isSharedImport(path, options) {

--- a/packages/module-federation-metro/src/plugin.ts
+++ b/packages/module-federation-metro/src/plugin.ts
@@ -6,6 +6,7 @@ import type { Resolution } from "metro-resolver";
 import generateManifest from "./generate-manifest";
 import { getModuleFederationSerializer } from "./serializer";
 import {
+  Shared,
   SharedConfig,
   ModuleFederationConfig,
   ModuleFederationConfigNormalized,
@@ -215,10 +216,12 @@ function createBabelTransformer({
   proxiedBabelTrasnsformerPath,
   mfConfig,
   mfMetroPath,
+  blacklistedPaths,
 }: {
   proxiedBabelTrasnsformerPath: string;
   mfConfig: ModuleFederationConfigNormalized;
   mfMetroPath: string;
+  blacklistedPaths: string[];
 }) {
   const babelTransformerPath = path.join(mfMetroPath, "babel-transformer.js");
 
@@ -229,7 +232,9 @@ function createBabelTransformer({
 
   const babelTransformer = babelTransformerTemplate
     .replaceAll("__BABEL_TRANSFORMER_PATH__", proxiedBabelTrasnsformerPath)
-    .replaceAll("__MF_CONFIG__", JSON.stringify(mfConfig));
+    .replaceAll("__REMOTES__", JSON.stringify(mfConfig.remotes))
+    .replaceAll("__SHARED__", JSON.stringify(mfConfig.shared))
+    .replaceAll("__BLACKLISTED_PATHS__", JSON.stringify(blacklistedPaths));
 
   fs.writeFileSync(babelTransformerPath, babelTransformer, "utf-8");
 
@@ -376,6 +381,7 @@ function withModuleFederation(
     proxiedBabelTrasnsformerPath: config.transformer.babelTransformerPath,
     mfMetroPath,
     mfConfig: options,
+    blacklistedPaths: [initHostPath, remoteEntryPath],
   });
 
   const manifestPath = createManifest(options, mfMetroPath);

--- a/packages/module-federation-metro/src/runtime/babel-transformer.js
+++ b/packages/module-federation-metro/src/runtime/babel-transformer.js
@@ -1,16 +1,25 @@
-const MF_CONFIG = __MF_CONFIG__;
+const blacklistedPaths = __BLACKLISTED_PATHS__;
+
+const remotes = __REMOTES__;
+const shared = __SHARED__;
+
 const proxiedBabelTransformer = require("__BABEL_TRANSFORMER_PATH__");
 
 function transform(config) {
-  const enhancedPlugins = [
-    ["module-federation-metro/babel/remotes-babel-plugin", MF_CONFIG],
-    ["module-federation-metro/babel/shared-babel-plugin", MF_CONFIG],
-    ...config.plugins,
+  const federationPlugins = [
+    [
+      "module-federation-metro/babel/remotes-babel-plugin",
+      { blacklistedPaths, remotes },
+    ],
+    [
+      "module-federation-metro/babel/shared-babel-plugin",
+      { blacklistedPaths, shared },
+    ],
   ];
 
   return proxiedBabelTransformer.transform({
     ...config,
-    plugins: enhancedPlugins,
+    plugins: [...federationPlugins, ...config.plugins],
   });
 }
 


### PR DESCRIPTION
### Summary

- [x] - remove slash from dynamic shared import detection regex
- [x] - blacklist `init-host` and `remote-entry` files from these babel transforms 