### PR TITLE
fix: bundle virtual container entry

### DIFF
--- a/apps/example-mini/package.json
+++ b/apps/example-mini/package.json
@@ -10,8 +10,8 @@
     "start": "rnef start --port 8082",
     "test": "jest",
     "pods": "(cd ios && bundle install && bundle exec pod install)",
-    "build:ios": "react-native bundle-mf-remote --platform ios",
-    "build:android": "react-native bundle-mf-remote --platform android",
+    "build:ios": "METRO_FEDERATION_DEV=1 rnef bundle-mf-remote --platform ios --dev false",
+    "build:android": "METRO_FEDERATION_DEV=1 rnef bundle-mf-remote --platform android --dev false",
     "serve:ios": "yarn build:ios && serve dist/ios -p 8082",
     "serve:android": "yarn build:android && serve dist/android -p 8082",
     "adbreverse": "adb reverse tcp:8082 tcp:8082"

--- a/apps/example-nested-mini/package.json
+++ b/apps/example-nested-mini/package.json
@@ -10,8 +10,8 @@
     "start": "rnef start --port 8083",
     "test": "jest",
     "pods": "(cd ios && bundle install && bundle exec pod install)",
-    "build:ios": "react-native bundle-mf-remote --platform ios",
-    "build:android": "react-native bundle-mf-remote --platform android",
+    "build:ios": "METRO_FEDERATION_DEV=1 rnef bundle-mf-remote --platform ios --dev false",
+    "build:android": "METRO_FEDERATION_DEV=1 rnef bundle-mf-remote --platform android --dev false",
     "serve:ios": "yarn build:ios && serve dist/ios -p 8083",
     "serve:android": "yarn build:android && serve dist/android -p 8083",
     "adbreverse": "adb reverse tcp:8083 tcp:8083"

--- a/apps/showcase-host/ios/host.xcodeproj/project.pbxproj
+++ b/apps/showcase-host/ios/host.xcodeproj/project.pbxproj
@@ -376,7 +376,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -445,7 +448,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/packages/module-federation-metro/src/commands/bundle-remote/index.ts
+++ b/packages/module-federation-metro/src/commands/bundle-remote/index.ts
@@ -241,10 +241,10 @@ async function bundleFederatedRemote(
       return !sharedConfig.eager && sharedConfig.import !== false;
     })
     .reduce((acc, [moduleName]) => {
-      const inputFilepath = resolver.resolve(
-        containerEntryFilepath,
-        moduleName
-      );
+      const inputFilepath = resolver.resolve({
+        from: containerEntryFilepath,
+        to: moduleName,
+      });
       acc[moduleName] = {
         moduleInputFilepath: inputFilepath,
         moduleOutputDir: path.resolve(outputDir, "shared"),

--- a/packages/module-federation-metro/src/commands/bundle-remote/index.ts
+++ b/packages/module-federation-metro/src/commands/bundle-remote/index.ts
@@ -198,7 +198,8 @@ async function bundleFederatedRemote(
   });
 
   const server = new Server(config);
-  // setup enhance middleware to trigger virtual modules setup
+
+  // hack: setup enhance middleware to trigger virtual modules setup
   config.server.enhanceMiddleware(server.processRequest, server);
 
   const resolver = await createResolver(server, args.platform);
@@ -217,6 +218,12 @@ async function bundleFederatedRemote(
       isContainerModule: true,
     },
   };
+
+  // hack: resolve the container entry to register it as a virtual module
+  resolver.resolve({
+    from: config.projectRoot,
+    to: `./${path.basename(containerEntryFilepath)}`,
+  });
 
   const exposedModules = Object.entries(federationConfig.exposes)
     .map(([moduleName, moduleFilepath]) => [

--- a/packages/module-federation-metro/src/commands/utils/createResolver.ts
+++ b/packages/module-federation-metro/src/commands/utils/createResolver.ts
@@ -18,7 +18,7 @@ export async function createResolver(server: Server, platform: string | null) {
   const bundler = server.getBundler().getBundler();
   const depGraph = await bundler.getDependencyGraph();
 
-  const resolve = (from: string, to: string) => {
+  const resolve = ({ from, to }: { from: string; to: string }) => {
     const config = { name: to, data: { asyncType: null, key: to, locs: [] } };
     const options = { assumeFlatNodeModules: false };
     const res = depGraph.resolveDependency(from, config, platform, {}, options);

--- a/packages/module-federation-metro/src/runtime-plugin.ts
+++ b/packages/module-federation-metro/src/runtime-plugin.ts
@@ -57,7 +57,7 @@ const MetroCorePlugin: () => FederationRuntimePlugin = () => ({
       await loadBundleAsync(entryUrl);
 
       if (!global.__METRO_FEDERATION__[entryGlobalName]) {
-        throw new Error();
+        throw new Error(`Remote entry ${entryGlobalName} failed to register.`);
       }
 
       global.__METRO_FEDERATION__[entryGlobalName].location = entryUrl;


### PR DESCRIPTION
### Summary

Introduction of virtual modules broke bundling - the command seemed to work because we stub the `remote-entry.js` on the filesystem. That stub was empty which caused containers to be essentially empty.

This PR fixes this behaviour by triggering creation of VM for the remote entrypoint in the `bundle-mf-remote` command