### PR TITLE
fix: use named exports for commands entrypoint

### DIFF
--- a/packages/module-federation-metro/src/commands/index.ts
+++ b/packages/module-federation-metro/src/commands/index.ts
@@ -3,6 +3,13 @@ import bundleFederatedRemote, {
   bundleFederatedRemoteOptions,
 } from './bundle-remote';
 
+export {
+  bundleFederatedHost,
+  bundleFederatedHostOptions,
+  bundleFederatedRemote,
+  bundleFederatedRemoteOptions,
+};
+
 export default {
   bundleFederatedHost,
   bundleFederatedHostOptions,


### PR DESCRIPTION
### Summary

for interop between ESM and CJS, I've brought back the named exports so that when CJS is imported from ESM it behaves like a default export either way (importing CJS from ESM causes an interop to be added that make CJS export into a default export)