### PR TITLE
feat: validate shared

### DIFF
--- a/packages/module-federation-metro/src/plugin/resolver.ts
+++ b/packages/module-federation-metro/src/plugin/resolver.ts
@@ -114,11 +114,6 @@ export function createResolveRequest({
         vmManager.registerVirtualModule(sharedPath, sharedGenerator);
         return { type: 'sourceFile', filePath: sharedPath };
       }
-      // TODO: module deep import
-      // if (importName.endsWith("/") && moduleName.startsWith(importName)) {
-      //   const sharedPath = createSharedModule(moduleName, paths.mfMetro);
-      //   return { type: "sourceFile", filePath: sharedPath };
-      // }
     }
 
     // replace getDevServer module in remote with our own implementation

--- a/packages/module-federation-metro/src/plugin/validate-options.ts
+++ b/packages/module-federation-metro/src/plugin/validate-options.ts
@@ -38,7 +38,8 @@ function validateShared(shared: Shared) {
     // disallow deep import wildcards (containing /)
     if (sharedName.endsWith('/')) {
       throw new ConfigError(
-        'Deep import wildcards are not supported as shared module names.'
+        'Deep import wildcards are not supported as shared module names. ' +
+          'You need to list all deep imports explicitly.'
       );
     }
   }

--- a/packages/module-federation-metro/src/plugin/validate-options.ts
+++ b/packages/module-federation-metro/src/plugin/validate-options.ts
@@ -18,6 +18,30 @@ function validateShared(shared: Shared) {
   if (Array.isArray(shared)) {
     throw new ConfigError('Array format is not supported for shared.');
   }
+
+  // validate shared module names
+  for (const sharedName of Object.keys(shared)) {
+    // disallow relative paths
+    if (sharedName.startsWith('./') || sharedName.startsWith('../')) {
+      throw new ConfigError(
+        'Relative paths are not supported as shared module names.'
+      );
+    }
+
+    // disallow absolute paths
+    if (sharedName.startsWith('/')) {
+      throw new ConfigError(
+        'Absolute paths are not supported as shared module names.'
+      );
+    }
+
+    // disallow deep import wildcards (containing /)
+    if (sharedName.endsWith('/')) {
+      throw new ConfigError(
+        'Deep import wildcards are not supported as shared module names.'
+      );
+    }
+  }
 }
 
 export function validateOptions(options: ModuleFederationConfigNormalized) {

--- a/packages/module-federation-metro/src/plugin/validate-options.ts
+++ b/packages/module-federation-metro/src/plugin/validate-options.ts
@@ -1,12 +1,29 @@
-import type { ModuleFederationConfigNormalized } from '../types';
+import type { ModuleFederationConfigNormalized, Shared } from '../types';
 import { ConfigError } from '../utils';
 
-export function validateOptions(options: ModuleFederationConfigNormalized) {
-  // validate filename
-  if (!options.filename.endsWith('.bundle')) {
+function validateFilename(filename: string) {
+  if (!filename.endsWith('.bundle')) {
     throw new ConfigError(
-      `Invalid filename: ${options.filename}. ` +
+      `Invalid filename: ${filename}. ` +
         'Filename must end with .bundle extension.'
     );
   }
+}
+
+function validateShared(shared: Shared) {
+  if (!shared || typeof shared !== 'object') {
+    throw new ConfigError('Shared must be an object.');
+  }
+
+  if (Array.isArray(shared)) {
+    throw new ConfigError('Array format is not supported for shared.');
+  }
+}
+
+export function validateOptions(options: ModuleFederationConfigNormalized) {
+  // validate filename
+  validateFilename(options.filename);
+
+  // validate shared
+  validateShared(options.shared);
 }


### PR DESCRIPTION
### Summary

- [x] - disallow relative paths as shared names
- [x] - disallow absolute paths as shared names
- [x] - disallow deep import wildcards (e.g. `react-native/`) as shared names 