### PR TITLE
fix: custom resolver

### DIFF
--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -182,6 +182,7 @@ function augmentConfig(
           patchHMRClient: flags.unstable_patchHMRClient,
           patchInitializeCore: flags.unstable_patchInitializeCore,
         },
+        customResolver: config.resolver.resolveRequest,
       }),
     },
     server: {


### PR DESCRIPTION
Description
`resolveRequest` is not accepted when it is provided inside the metro config 

How to test it? 
```
const config = {
  resolver: {
    useWatchman: false,
    resolveRequest: (context, moduleName, platform) => {
      console.log('[Custom Resolver] Resolving:', moduleName);
      return context.resolveRequest(context, moduleName, platform);
    },
  },
  ```